### PR TITLE
Fix doors' loot tables

### DIFF
--- a/src/main/generated/data/maple/loot_tables/blocks/bamboo_door.json
+++ b/src/main/generated/data/maple/loot_tables/blocks/bamboo_door.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "maple:bamboo_door",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "maple:bamboo_door"
         }
       ],

--- a/src/main/generated/data/maple/loot_tables/blocks/cherry_door.json
+++ b/src/main/generated/data/maple/loot_tables/blocks/cherry_door.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "maple:cherry_door",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "maple:cherry_door"
         }
       ],

--- a/src/main/generated/data/maple/loot_tables/blocks/maple_door.json
+++ b/src/main/generated/data/maple/loot_tables/blocks/maple_door.json
@@ -11,6 +11,15 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "maple:maple_door",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
           "name": "maple:maple_door"
         }
       ],

--- a/src/main/java/com/skniro/maple/datagen/MapleLootTableGenerator.java
+++ b/src/main/java/com/skniro/maple/datagen/MapleLootTableGenerator.java
@@ -35,7 +35,7 @@ public class MapleLootTableGenerator extends SimpleFabricLootTableProvider {
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/cherry_wood"),
                 BlockLootTableGenerator.drops(MapleBlocks.CHERRY_WOOD));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/cherry_door"),
-                BlockLootTableGenerator.drops(MapleBlocks.CHERRY_DOOR));
+                BlockLootTableGenerator.doorDrops(MapleBlocks.CHERRY_DOOR));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/cherry_sapling"),
                 BlockLootTableGenerator.drops(MapleBlocks.CHERRY_SAPLING));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/cherry_leaves"),
@@ -73,7 +73,7 @@ public class MapleLootTableGenerator extends SimpleFabricLootTableProvider {
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/maple_wood"),
                 BlockLootTableGenerator.drops(MapleBlocks.MAPLE_WOOD));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/maple_door"),
-                BlockLootTableGenerator.drops(MapleBlocks.MAPLE_DOOR));
+                BlockLootTableGenerator.doorDrops(MapleBlocks.MAPLE_DOOR));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/maple_sapling"),
                 BlockLootTableGenerator.drops(MapleBlocks.MAPLE_SAPLING));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/maple_leaves"),
@@ -113,7 +113,7 @@ public class MapleLootTableGenerator extends SimpleFabricLootTableProvider {
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/bamboo_mosaic"),
                 BlockLootTableGenerator.drops(MapleBlocks.BAMBOO_MOSAIC));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/bamboo_door"),
-                BlockLootTableGenerator.drops(MapleBlocks.BAMBOO_DOOR));
+                BlockLootTableGenerator.doorDrops(MapleBlocks.BAMBOO_DOOR));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/bamboo_button"),
                 BlockLootTableGenerator.drops(MapleBlocks.BAMBOO_BUTTON));
         identifierBuilderBiConsumer.accept(new Identifier(Maple.MOD_ID, "blocks/bamboo_fence"),


### PR DESCRIPTION
This changes the door's loot table datagen to use BlockLootTableGenerator#doorDrops instead of just BlockLootTableGenerator#drops to fix doors dropping twice (once for the upper half, another for the bottom half). Fixes #10.